### PR TITLE
feat: check boat speed after model checking to avoid useless notification

### DIFF
--- a/client/utils.lua
+++ b/client/utils.lua
@@ -3,11 +3,6 @@ function canAnchor(vehicle)
         return false
     end
 
-    if GetEntitySpeed(vehicle) > tonumber(shared.maxSpeed) then
-        onTooFast(vehicle)
-        return false
-    end
-
     local model = GetEntityModel(vehicle)
 
     if not model or model == 0 then
@@ -15,6 +10,11 @@ function canAnchor(vehicle)
     end
 
     if not (IsThisModelABoat(model) or IsThisModelAJetski(model) or IsThisModelAnAmphibiousCar(model) or IsThisModelAnAmphibiousQuadbike(model)) then
+        return false
+    end
+
+    if GetEntitySpeed(vehicle) > tonumber(shared.maxSpeed) then
+        onTooFast(vehicle)
         return false
     end
 


### PR DESCRIPTION
To avoid notification when player types /anchor on a non-boat vehicle